### PR TITLE
fix: use UTC in calculate method to eliminate dependency on local time

### DIFF
--- a/lib/fast_xirr.rb
+++ b/lib/fast_xirr.rb
@@ -3,7 +3,7 @@ require 'fast_xirr/fast_xirr'
 module FastXirr
   def self.calculate(cashflows:, tol: 1e-7, max_iter: 1e10)
     cashflows_with_timestamps = cashflows.map do |amount, date|
-      [amount, date.to_time.to_i]
+      [amount, Time.utc(date.year, date.month, date.day).to_i]
     end
     result = _calculate_with_brent(cashflows_with_timestamps, tol, max_iter)
     


### PR DESCRIPTION
By default, [`Time`](https://docs.ruby-lang.org/en/master/Time.html) uses the local timezone. This can cause discrepancies in cases where only some dates in a cash flow involve Daylight Saving Time (DST) in the machine's timezone, as the difference between two days may not always be 86400 seconds.

To eliminate these inconsistencies, we propose using `Time.utc`.