### PR TITLE
Gem and ruby version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,9 +164,9 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+ Gemfile.lock
+ .ruby-version
+ .ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'rspec'
-
+group :test, :development do
+  gem 'rake'
+  gem 'rake-compiler'
+  gem 'rspec'
+end


### PR DESCRIPTION
We propose two small quality-of-life improvements:

- Ignore `.ruby-version` by default, so our local environment can be set this way.
- Install `'rake-compiler'` as dev and test dependency, otherwise tests won't run.
- Install all other dependencies in dev and test group, as they are only for that.