### PR TITLE
Add CI actions to build and test the gem + Fixes in C Core for Windows ☠️ 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,37 @@
+name: Build and Test Gem 
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ruby-version: ['3']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Compile native extension
+      run: bundle exec rake compile
+
+    - name: Build the Gem
+      run: gem build fast_xirr.gemspec
+
+    - name: Install the Gem
+      run: gem install ./fast_xirr-*.gem --no-document
+
+    - name: Run tests
+      run: rake test

--- a/ext/fast_xirr/bisection.c
+++ b/ext/fast_xirr/bisection.c
@@ -17,7 +17,7 @@
  *
  * @return The estimated root (XIRR) or NAN if it fails to converge.
  */
-double bisection_method(CashFlow *cashflows, long count, double tol, long max_iter, double low, double high) {
+double bisection_method(CashFlow *cashflows, long long count, double tol, long long max_iter, double low, double high) {
     double mid, f_low, f_mid, f_high;
 
     // Calculate the NPV at the boundaries of the interval
@@ -30,7 +30,7 @@ double bisection_method(CashFlow *cashflows, long count, double tol, long max_it
     }
 
     // Iteratively apply the bisection method
-    for (long iter = 0; iter < max_iter; iter++) {
+    for (long long iter = 0; iter < max_iter; iter++) {
         mid = (low + high) / 2.0;
         f_mid = npv(mid, cashflows, count, cashflows[0].date);
 
@@ -65,11 +65,11 @@ double bisection_method(CashFlow *cashflows, long count, double tol, long max_it
  */
 VALUE calculate_xirr_with_bisection(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VALUE rb_max_iter) {
     // Get the number of cash flows
-    long count = RARRAY_LEN(rb_cashflows);
+    long long count = RARRAY_LEN(rb_cashflows);
     CashFlow cashflows[count];
 
     // Convert Ruby cash flows array to C array
-    for (long i = 0; i < count; i++) {
+    for (long long i = 0; i < count; i++) {
         VALUE rb_cashflow = rb_ary_entry(rb_cashflows, i);
         cashflows[i].amount = NUM2DBL(rb_ary_entry(rb_cashflow, 0));
         cashflows[i].date = (time_t)NUM2LONG(rb_ary_entry(rb_cashflow, 1));
@@ -77,7 +77,7 @@ VALUE calculate_xirr_with_bisection(VALUE self, VALUE rb_cashflows, VALUE rb_tol
 
     // Convert tolerance and max iterations to C types
     double tol = NUM2DBL(rb_tol);
-    long max_iter = NUM2LONG(rb_max_iter);
+    long long max_iter = NUM2LL(rb_max_iter);
 
     // Initial standard bracketing interval
     double low = -0.999999, high = 100.0;

--- a/ext/fast_xirr/bisection.c
+++ b/ext/fast_xirr/bisection.c
@@ -1,5 +1,5 @@
 #include <ruby.h>
-#include <time.h>
+#include <stdint.h>
 #include <math.h>
 #include "bisection.h"
 #include "common.h"
@@ -72,7 +72,7 @@ VALUE calculate_xirr_with_bisection(VALUE self, VALUE rb_cashflows, VALUE rb_tol
     for (long long i = 0; i < count; i++) {
         VALUE rb_cashflow = rb_ary_entry(rb_cashflows, i);
         cashflows[i].amount = NUM2DBL(rb_ary_entry(rb_cashflow, 0));
-        cashflows[i].date = (time_t)NUM2LONG(rb_ary_entry(rb_cashflow, 1));
+        cashflows[i].date = (int64_t)NUM2LL(rb_ary_entry(rb_cashflow, 1));
     }
 
     // Convert tolerance and max iterations to C types

--- a/ext/fast_xirr/brent.c
+++ b/ext/fast_xirr/brent.c
@@ -1,5 +1,5 @@
 #include <ruby.h>
-#include <time.h>
+#include <stdint.h>
 #include <math.h>
 #include "brent.h"
 #include "common.h"
@@ -123,8 +123,9 @@ VALUE calculate_xirr_with_brent(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VA
     for (long long i = 0; i < count; i++) {
         VALUE rb_cashflow = rb_ary_entry(rb_cashflows, i);
         cashflows[i].amount = NUM2DBL(rb_ary_entry(rb_cashflow, 0));
-        cashflows[i].date = (time_t)NUM2LONG(rb_ary_entry(rb_cashflow, 1));
+        cashflows[i].date = (int64_t)NUM2LL(rb_ary_entry(rb_cashflow, 1));
     }
+
 
     // Convert tolerance and max iterations to C types
     double tol = NUM2DBL(rb_tol);
@@ -134,6 +135,7 @@ VALUE calculate_xirr_with_brent(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VA
 
     // Try Brent's method with a standard bracketing interval
     double low = -0.9999, high = 10.0;
+
     result = brent_method(cashflows, count, tol, max_iter, low, high);
     if (!isnan(result)) {
         return rb_float_new(result);

--- a/ext/fast_xirr/brent.c
+++ b/ext/fast_xirr/brent.c
@@ -17,7 +17,7 @@
  *
  * @return The estimated root (XIRR) or NAN if it fails to converge.
  */
-double brent_method(CashFlow *cashflows, long count, double tol, long max_iter, double low, double high) {
+double brent_method(CashFlow *cashflows, long long count, double tol, long long max_iter, double low, double high) {
     // Calculate the NPV at the boundaries of the interval
     double fa = npv(low, cashflows, count, cashflows[0].date);
     double fb = npv(high, cashflows, count, cashflows[0].date);
@@ -30,7 +30,7 @@ double brent_method(CashFlow *cashflows, long count, double tol, long max_iter, 
     double c = low, fc = fa, s, d = 0.0, e = 0.0;
 
     // Iteratively apply Brent's method
-    for (long iter = 0; iter < max_iter; iter++) {
+    for (long long iter = 0; iter < max_iter; iter++) {
         if (fb * fc > 0) {
             // Adjust c to ensure that f(b) and f(c) have opposite signs
             c = low;
@@ -116,11 +116,11 @@ double brent_method(CashFlow *cashflows, long count, double tol, long max_iter, 
  */
 VALUE calculate_xirr_with_brent(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VALUE rb_max_iter) {
     // Get the number of cash flows
-    long count = RARRAY_LEN(rb_cashflows);
+    long long count = (long long)RARRAY_LEN(rb_cashflows);
     CashFlow cashflows[count];
 
     // Convert Ruby cash flows array to C array
-    for (long i = 0; i < count; i++) {
+    for (long long i = 0; i < count; i++) {
         VALUE rb_cashflow = rb_ary_entry(rb_cashflows, i);
         cashflows[i].amount = NUM2DBL(rb_ary_entry(rb_cashflow, 0));
         cashflows[i].date = (time_t)NUM2LONG(rb_ary_entry(rb_cashflow, 1));
@@ -128,7 +128,7 @@ VALUE calculate_xirr_with_brent(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VA
 
     // Convert tolerance and max iterations to C types
     double tol = NUM2DBL(rb_tol);
-    long max_iter = NUM2LONG(rb_max_iter);
+    long long max_iter = NUM2LL(rb_max_iter);
 
     double result;
 

--- a/ext/fast_xirr/common.c
+++ b/ext/fast_xirr/common.c
@@ -11,13 +11,13 @@
  *
  * @return The calculated NPV.
  */
-double npv(double rate, CashFlow *cashflows, long long count, time_t min_date) {
+double npv(double rate, CashFlow *cashflows, long long count, int64_t min_date) {
     double npv_value = 0.0;
 
     for (long long i = 0; i < count; i++) {
         // Calculate the number of days from the minimum date to the cash flow date
-        double days = difftime(cashflows[i].date, min_date) / (60 * 60 * 24);
-        
+        double days = (double)(cashflows[i].date - min_date) / (60 * 60 * 24);
+
         // Calculate the discount factor and add the discounted amount to the NPV
         npv_value += cashflows[i].amount / pow(1 + rate, days / 365.0);
     }
@@ -40,7 +40,7 @@ double npv(double rate, CashFlow *cashflows, long long count, time_t min_date) {
 int find_bracketing_interval(CashFlow *cashflows, long long count, double *low, double *high) {
     double min_rate = -0.99999999, max_rate = 10.0;
     double step = 0.0001;
-    time_t min_date = cashflows[0].date;
+    int64_t min_date = cashflows[0].date;
 
     // Find the earliest date in the cashflows array
     for (long long i = 1; i < count; i++) {

--- a/ext/fast_xirr/common.c
+++ b/ext/fast_xirr/common.c
@@ -11,10 +11,10 @@
  *
  * @return The calculated NPV.
  */
-double npv(double rate, CashFlow *cashflows, long count, time_t min_date) {
+double npv(double rate, CashFlow *cashflows, long long count, time_t min_date) {
     double npv_value = 0.0;
 
-    for (long i = 0; i < count; i++) {
+    for (long long i = 0; i < count; i++) {
         // Calculate the number of days from the minimum date to the cash flow date
         double days = difftime(cashflows[i].date, min_date) / (60 * 60 * 24);
         
@@ -37,13 +37,13 @@ double npv(double rate, CashFlow *cashflows, long count, time_t min_date) {
  *
  * @return 1 if a bracketing interval is found, 0 otherwise.
  */
-int find_bracketing_interval(CashFlow *cashflows, long count, double *low, double *high) {
+int find_bracketing_interval(CashFlow *cashflows, long long count, double *low, double *high) {
     double min_rate = -0.99999999, max_rate = 10.0;
     double step = 0.0001;
     time_t min_date = cashflows[0].date;
 
     // Find the earliest date in the cashflows array
-    for (long i = 1; i < count; i++) {
+    for (long long i = 1; i < count; i++) {
         if (cashflows[i].date < min_date) {
             min_date = cashflows[i].date;
         }

--- a/ext/fast_xirr/common.h
+++ b/ext/fast_xirr/common.h
@@ -1,14 +1,14 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include <time.h>
+#include <stdint.h>
 
 typedef struct {
     double amount;
-    time_t date;
+    int64_t date;
 } CashFlow;
 
-double npv(double rate, CashFlow *cashflows, long long count, time_t min_date);
+double npv(double rate, CashFlow *cashflows, long long count, int64_t min_date);
 
 int find_bracketing_interval(CashFlow *cashflows, long long count, double *low, double *high);
 

--- a/ext/fast_xirr/common.h
+++ b/ext/fast_xirr/common.h
@@ -8,8 +8,8 @@ typedef struct {
     time_t date;
 } CashFlow;
 
-double npv(double rate, CashFlow *cashflows, long count, time_t min_date);
+double npv(double rate, CashFlow *cashflows, long long count, time_t min_date);
 
-int find_bracketing_interval(CashFlow *cashflows, long count, double *low, double *high);
+int find_bracketing_interval(CashFlow *cashflows, long long count, double *low, double *high);
 
 #endif


### PR DESCRIPTION
### Hey there 👋 

This PR introduces several important updates to improve our CI pipeline and ensure better cross-platform compatibility for our C core. 

### Here’s a breakdown of the changes:

#### 🚀 CI Updates
- Added a new GitHub Action that automatically builds and tests the gem on every pull request. This action runs on the latest version of Ruby 3 across Windows, Ubuntu, and macOS. ✅

- I chose to test only the latest versions of Ruby 3 to balance thoroughness and resource usage. Testing every version on every PR would be too expensive, but we can create later an action that runs checks on all versions for version releases. 💯 



#### 🔧 C Core Improvements
- Changed variable types from `long` to `long long `to ensure proper handling of large values on Windows. This prevents potential issues where `long` is 32 bits on Windows, which could lead to incorrect conversions and overflow. 🛠️

- Switched from `time_t` to `int64_t` for date handling to avoid inconsistencies, especially with dates before the Unix epoch. 📅
>Note: On Windows, handling of `time_t` with negative values (dates before the Unix epoch) can be inconsistent. The C runtime libraries on Windows may not handle negative `time_t` values correctly, leading to issues with functions like `difftime` returning incorrect or zero results. This is due to differences in how time representations are implemented across platforms. 

By making these changes, we ensure that our gem builds and runs smoothly across different operating systems, and we improve the robustness of our date handling and large value computations. 🌍

Thank you for reviewing these changes! Please let me know if you have any questions or need further clarifications.