### PR TITLE
refactor: sort cashflows by timestamp in calculate method

### DIFF
--- a/lib/fast_xirr.rb
+++ b/lib/fast_xirr.rb
@@ -4,7 +4,8 @@ module FastXirr
   def self.calculate(cashflows:, tol: 1e-7, max_iter: 1e10)
     cashflows_with_timestamps = cashflows.map do |amount, date|
       [amount, Time.utc(date.year, date.month, date.day).to_i]
-    end
+    end.sort_by { |_amount, timestamp| timestamp }
+
     result = _calculate_with_brent(cashflows_with_timestamps, tol, max_iter)
     
     if result.nan?


### PR DESCRIPTION
Although calculations might work with unsorted cash flows, it is more accurate to provide the solvers with sorted cash flows. Both methods, [bisection](https://github.com/fintual-oss/fast-xirr/blob/b9333d9e8ca03c6ca6460f4eeee614a4ea9becea/ext/fast_xirr/bisection.c#L24-L25) and [brent](https://github.com/fintual-oss/fast-xirr/blob/b9333d9e8ca03c6ca6460f4eeee614a4ea9becea/ext/fast_xirr/brent.c#L22-L23), rely on having sorted cash flows to feed the NPV function with the minimum timestamp.

**Changes**

- Sort cashflow array before calling numeric methods