### PR TITLE
Fix issue where empty cashflows array returned 10.0 instead of 0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Fix: Resolved an issue where calculating XIRR with an empty cash flow array returned 10. It now correctly returns 0.
+
 ## 1.0.0 / 2024-07-03
 
 ### Initial Release 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ To build the gem from the source code, follow these steps:
     gem build fast_xirr.gemspec
     ```
 
-    This will create a `.gem` file in the directory, such as `fast_xirr-1.0.0.gem`.
+    This will create a `.gem` file in the directory, such as `fast_xirr-1.x.x.gem`.
 
 3. **Install the Gem Locally**:
 
     ```bash
-    gem install ./fast_xirr-1.0.0.gem
+    gem install ./fast_xirr*.gem
     ```
 
 ### Testing the Gem

--- a/ext/fast_xirr/bisection.c
+++ b/ext/fast_xirr/bisection.c
@@ -20,6 +20,11 @@
 double bisection_method(CashFlow *cashflows, long long count, double tol, long long max_iter, double low, double high) {
     double mid, f_low, f_mid, f_high;
 
+    //If cashflows are empty, return 0
+    if (count == 0) {
+        return 0.0;
+    }
+
     // Calculate the NPV at the boundaries of the interval
     f_low = npv(low, cashflows, count, cashflows[0].date);
     f_high = npv(high, cashflows, count, cashflows[0].date);

--- a/ext/fast_xirr/brent.c
+++ b/ext/fast_xirr/brent.c
@@ -18,6 +18,11 @@
  * @return The estimated root (XIRR) or NAN if it fails to converge.
  */
 double brent_method(CashFlow *cashflows, long long count, double tol, long long max_iter, double low, double high) {
+    //If cashflows are empty, return 0
+    if (count == 0) {
+        return 0.0;
+    }
+
     // Calculate the NPV at the boundaries of the interval
     double fa = npv(low, cashflows, count, cashflows[0].date);
     double fb = npv(high, cashflows, count, cashflows[0].date);

--- a/fast_xirr.gemspec
+++ b/fast_xirr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "fast_xirr"
-  spec.version       = "1.0.0"
+  spec.version       = "1.0.1"
   spec.authors       = ["Matias Martini"]
   spec.email         = ["martini@fintual.com"]
 

--- a/lib/fast_xirr/version.rb
+++ b/lib/fast_xirr/version.rb
@@ -1,4 +1,4 @@
 module FastXirr
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end
 

--- a/spec/fast_xirr_spec.rb
+++ b/spec/fast_xirr_spec.rb
@@ -58,5 +58,12 @@ RSpec.describe FastXirr do
       result = FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-13)
       expect(result).to be_within(1e-12).of(0.22568333231765117)
     end
+
+    it 'returns 0 with an empty array of cash flows' do
+      cashflows = []
+
+      result = FastXirr.calculate(cashflows: cashflows)
+      expect(result).to be_zero
+    end
   end
 end


### PR DESCRIPTION
### Context

We noticed that when calculating XIRR with an empty array of cash flows, it was returning 10 instead of the correct value 0. This happened because our initial value to begin the iteration (10) was being returned by default due to `npv` returning 0 with a `count` of 0, which led Brent or Bisect to incorrectly think the initial value solved the equation.

In this PR, we’ve added a check for empty cash flow arrays. Now, if the array is empty, it will correctly return 0.

### QA

Added a test with an empty cash flow array to ensure it returns 0 as expected.
