### PR TITLE
Fix dynamic rate step bracketing interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## 1.0.2
+
+- Fixed: The `find_bracketing_interval` function now supports extremely high rates, improving precision for very high XIRRs (over 1E300%). Dynamic step sizing ensures accurate results even at extreme rates.
+
 ## 1.0.1
 
-- Fix: Resolved an issue where calculating XIRR with an empty cash flow array returned 10. It now correctly returns 0.
+- Fixed: Resolved an issue where calculating XIRR with an empty cash flow array returned 10. It now correctly returns 0.
 
 ## 1.0.0 / 2024-07-03
 
-### Initial Release 
+### Initial Release
 

--- a/ext/fast_xirr/common.c
+++ b/ext/fast_xirr/common.c
@@ -66,13 +66,12 @@ int find_bracketing_interval(CashFlow *cashflows, long long count, double *low, 
     }
 
     // Extend the search range if no interval is found within the initial range
-    step = 10.0;
-    for (double rate = max_rate + step; rate <= 10000.0; rate += step) {
+    for (double rate = max_rate; rate <= 1e300; rate *= 1.5) {
         double npv_rate = npv(rate, cashflows, count, min_date);
 
         // Check if the function values at consecutive rates have opposite signs
         if (npv_min_rate * npv_rate < 0) {
-            *low = rate - step;
+            *low = rate / 1.5;
             *high = rate;
             return 1;
         }

--- a/spec/use_cases_spec.rb
+++ b/spec/use_cases_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe FastXirr do
     expect(result).to be_within(1e-6).of(22.35220616417055)
   end
 
-  it 'returns NaN for a good investment that cannot be annualized' do
+  it 'calculates xirr for an extremely good and unrealistic investment' do
     cashflows = [
       [-1000, Date.new(1985, 1, 1)],
       [6000, Date.new(1985, 1, 2)]
     ]
 
     result = FastXirr.calculate(cashflows: cashflows)
-    expect(result.nan?).to be true
+    expect(result).to be_within(1e-6).of(1.0597571969623571e+284)
   end
 
   it 'returns NaN for all negative cashflows' do


### PR DESCRIPTION
## Context

Hey there! 👋

In this PR, I tackled a precision issue we were having in the `find_bracketing_interval` function when searching for bracketing intervals at very large rates. Originally, the max rate was capped at 10.0, but we've now increased that to 1E300. The fixed step size approach wasn't cutting it, leading to floating-point precision problems as the rate got larger.

To address this, I introduced a dynamic step size that adjusts as the rate increases. This allows us to explore higher values effectively (all the way up to 1E300!) without running into precision issues. The new approach uses a logarithmic-like step, ensuring better coverage and stability across the entire range.

## Changelog

- Fixed: The `find_bracketing_interval` function now supports extremely high rates, improving precision for very high XIRRs (over 1E300%). Dynamic step sizing ensures accurate results even at extreme rates.

## QA

Now the extremely good investment converges in the specs:

```ruby
  it 'calculates xirr for an extremely good and unrealistic investment' do
    cashflows = [
      [-1000, Date.new(1985, 1, 1)],
      [6000, Date.new(1985, 1, 2)]
    ]

    result = FastXirr.calculate(cashflows: cashflows)
    expect(result).to be_within(1e-6).of(1.0597571969623571e+284)
  end
```

