### PR TITLE
Add Initial Bracket Parameter for Brent Solver in FastXIRR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Added: New optional `initial_bracket` parameter allows customizing the search interval for Brent's method. This enables users to guide the algorithm towards specific rate ranges or help convergence in challenging scenarios.
+- Change: Default Brent's method search initial interval changed from [0.999, 10.0] to [0.3, 10.0]. This improves convergence in typical financial scenarios where multiple solutions exist.
+
 ## 1.0.2
 
 - Fixed: The `find_bracketing_interval` function now supports extremely high rates, improving precision for very high XIRRs (over 1E300%). Dynamic step sizing ensures accurate results even at extreme rates.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ result.nan?
 # => true
 ```
 
-Tolerance can be set to a custom value (default is 1e-7), as well as the maximum number of iterations (default is 1e10).
+Tolerance can be set to a custom value (default is 1e-7), as well as the maximum number of iterations (default is 1e10). You can also specify the initial bracket interval for Brent's method (default is [-0.3, 10.0]) to help the algorithm converge in specific ranges. If the algorith doesn't converge, it will expand the brackets to [0.999, 100.0].
 
 
 ```ruby
@@ -86,6 +86,14 @@ puts "XIRR: #{result}"
 result = FastXirr.calculate(cashflows: cashflows, tol: 1e-8, max_iter: 2)
 puts "XIRR: #{result}"
 # => XIRR: NaN
+
+# You can also specify the initial bracket (search interval) for Brent's method
+result = FastXirr.calculate(
+  cashflows: cashflows,
+  initial_bracket: [-0.5, 5.0]
+)
+puts "XIRR: #{result}"
+# => XIRR: 0.22568333743016633
 ```
 
 ## Build and test

--- a/ext/fast_xirr/brent.h
+++ b/ext/fast_xirr/brent.h
@@ -1,9 +1,9 @@
-#ifndef BRENT_H  
+#ifndef BRENT_H
 #define BRENT_H
 
 #include <ruby.h>
 
-VALUE calculate_xirr_with_brent(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VALUE rb_max_iter);
+VALUE calculate_xirr_with_brent(VALUE self, VALUE rb_cashflows, VALUE rb_tol, VALUE rb_max_iter, VALUE rb_brackets);
 
 #endif
 

--- a/ext/fast_xirr/xirr.c
+++ b/ext/fast_xirr/xirr.c
@@ -1,5 +1,5 @@
 #include <ruby.h>
-#include "brent.h" 
+#include "brent.h"
 #include "bisection.h"
 
 /**
@@ -8,5 +8,5 @@
 void Init_fast_xirr(void) {
     VALUE XirrModule = rb_define_module("FastXirr");
     rb_define_singleton_method(XirrModule, "_calculate_with_bisection", calculate_xirr_with_bisection, 3);
-    rb_define_singleton_method(XirrModule, "_calculate_with_brent", calculate_xirr_with_brent, 3);
+    rb_define_singleton_method(XirrModule, "_calculate_with_brent", calculate_xirr_with_brent, 4);
 }

--- a/lib/fast_xirr.rb
+++ b/lib/fast_xirr.rb
@@ -1,13 +1,13 @@
 require 'fast_xirr/fast_xirr'
 
 module FastXirr
-  def self.calculate(cashflows:, tol: 1e-7, max_iter: 1e10)
+  def self.calculate(cashflows:, tol: 1e-7, max_iter: 1e10, initial_bracket: [-0.3,10.0])
     cashflows_with_timestamps = cashflows.map do |amount, date|
       [amount, Time.utc(date.year, date.month, date.day).to_i]
     end.sort_by { |_amount, timestamp| timestamp }
 
-    result = _calculate_with_brent(cashflows_with_timestamps, tol, max_iter)
-    
+    result = _calculate_with_brent(cashflows_with_timestamps, tol, max_iter, initial_bracket)
+
     if result.nan?
       result = _calculate_with_bisection(cashflows_with_timestamps, tol, max_iter)
     end

--- a/spec/use_cases_spec.rb
+++ b/spec/use_cases_spec.rb
@@ -293,4 +293,84 @@ RSpec.describe FastXirr do
     result = FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-6)
     expect(result).to be_within(1e-6).of(-0.9999999899975666)
   end
+
+  it 'calculates expected xirr with default initial brackets and when xirr have multiple results' do
+    cashflows = [
+      [-224291642.5, Date.new(1980, 1, 1)],
+      [-259470950.8, Date.new(1981, 1, 1)],
+      [-396990554.7, Date.new(1982, 1, 1)],
+      [-134976788.6, Date.new(1983, 1, 1)],
+      [-413028973.1, Date.new(1984, 1, 1)],
+      [0, Date.new(1985, 1, 1)],
+      [171774601.6, Date.new(1986, 1, 1)],
+      [175210093.6, Date.new(1987, 1, 1)],
+      [178714295.5, Date.new(1988, 1, 1)],
+      [182288581.4, Date.new(1989, 1, 1)],
+      [185934353, Date.new(1990, 1, 1)],
+      [189653040.1, Date.new(1991, 1, 1)],
+      [193446100.9, Date.new(1992, 1, 1)],
+      [197315022.9, Date.new(1993, 1, 1)],
+      [201261323.3, Date.new(1994, 1, 1)],
+      [205286549.8, Date.new(1995, 1, 1)],
+      [209392280.8, Date.new(1996, 1, 1)],
+      [213580126.4, Date.new(1997, 1, 1)],
+      [217851728.9, Date.new(1998, 1, 1)],
+      [222208763.5, Date.new(1999, 1, 1)],
+      [70921057.8, Date.new(2000, 1, 1)],
+      [72339479, Date.new(2001, 1, 1)],
+      [73786268.6, Date.new(2002, 1, 1)],
+      [75261993.9, Date.new(2003, 1, 1)],
+      [76767233.8, Date.new(2004, 1, 1)],
+      [78302578.5, Date.new(2005, 1, 1)],
+      [79868630.1, Date.new(2006, 1, 1)],
+      [81466002.7, Date.new(2007, 1, 1)],
+      [83095322.7, Date.new(2008, 1, 1)],
+      [84757229.2, Date.new(2009, 1, 1)],
+      [86452373.8, Date.new(2010, 1, 1)],
+      [-34820484.1, Date.new(2011, 1, 1)]
+    ]
+
+    result = FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-6, initial_bracket: [-0.999, 1.0])
+    expect(result).to be_within(1e-6).of(-0.7111929106775536)
+  end
+
+  it 'calculates expected xirr with non-default initial brackets and when xirr have multiple results' do
+    cashflows = [
+      [-224291642.5, Date.new(1980, 1, 1)],
+      [-259470950.8, Date.new(1981, 1, 1)],
+      [-396990554.7, Date.new(1982, 1, 1)],
+      [-134976788.6, Date.new(1983, 1, 1)],
+      [-413028973.1, Date.new(1984, 1, 1)],
+      [0, Date.new(1985, 1, 1)],
+      [171774601.6, Date.new(1986, 1, 1)],
+      [175210093.6, Date.new(1987, 1, 1)],
+      [178714295.5, Date.new(1988, 1, 1)],
+      [182288581.4, Date.new(1989, 1, 1)],
+      [185934353, Date.new(1990, 1, 1)],
+      [189653040.1, Date.new(1991, 1, 1)],
+      [193446100.9, Date.new(1992, 1, 1)],
+      [197315022.9, Date.new(1993, 1, 1)],
+      [201261323.3, Date.new(1994, 1, 1)],
+      [205286549.8, Date.new(1995, 1, 1)],
+      [209392280.8, Date.new(1996, 1, 1)],
+      [213580126.4, Date.new(1997, 1, 1)],
+      [217851728.9, Date.new(1998, 1, 1)],
+      [222208763.5, Date.new(1999, 1, 1)],
+      [70921057.8, Date.new(2000, 1, 1)],
+      [72339479, Date.new(2001, 1, 1)],
+      [73786268.6, Date.new(2002, 1, 1)],
+      [75261993.9, Date.new(2003, 1, 1)],
+      [76767233.8, Date.new(2004, 1, 1)],
+      [78302578.5, Date.new(2005, 1, 1)],
+      [79868630.1, Date.new(2006, 1, 1)],
+      [81466002.7, Date.new(2007, 1, 1)],
+      [83095322.7, Date.new(2008, 1, 1)],
+      [84757229.2, Date.new(2009, 1, 1)],
+      [86452373.8, Date.new(2010, 1, 1)],
+      [-34820484.1, Date.new(2011, 1, 1)]
+    ]
+
+    result = FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-6)
+    expect(result).to be_within(1e-6).of(0.07847712563567992)
+  end
 end


### PR DESCRIPTION
## Context

Issue #9 

`fast-xirr` solves for the extended internal rate of return (XIRR) using the Brent method. Currently, the solver starts with a fixed bracket (-0.9999 to 10.0). However, certain cash flow sequences can have multiple valid XIRR solutions, and the choice of the initial search range influences which solution the algorithm converges to.  

Since the solver does not allow users to adjust the initial bracket, it may converge to an unintended XIRR, especially in cases where multiple roots exist. This change provides a way for users to guide the solver by defining a custom initial bracket. Additionally, the default bracket is being adjusted closer to 0, ensuring that the solver starts from a range that better reflects real-world return rates.

## Objective

- Introduce a configurable `initial_bracket` parameter to allow users to control the solver's **initial** search range.
- Adjust the default initial bracket to a more representative range `([-0.5, 1.0])` to align with realistic return values.
- Improve the flexibility of the solver to handle cases where multiple XIRRs exist, reducing the likelihood of convergence to an unintended solution.


## Use

```ruby
# You can also specify the initial bracket (search interval) for Brent's method
result = FastXirr.calculate(
  cashflows: cashflows,
  initial_bracket: [-0.5, 5.0]
)
puts "XIRR: #{result}"
# => XIRR: 0.22568333743016633
```

## Changelog

- **New feature**: Added `initial_bracket`:` [low, high]` parameter to xirr, allowing users to specify the solver's initial search bracket.
- Changed default behavior:
  - If `initial_bracket` is not provided, `fast-xirr` now defaults to `[-0.3, 10.0]` instead of `[-0.9999, 10.0]`.
  - This ensures the solver starts from a more reasonable range that aligns with expected return distributions.
- Refactored solver logic: The Brent solver now dynamically adapts based on the provided bracket.

## QA

- Tests
- Locally tested

```ruby

require "fast_xirr"
require "date"

cashflows = [
  [-224291642.5, Date.new(1980, 1, 1)],
  [-259470950.8, Date.new(1981, 1, 1)],
  [-396990554.7, Date.new(1982, 1, 1)],
  [-134976788.6, Date.new(1983, 1, 1)],
  [-413028973.1, Date.new(1984, 1, 1)],
  [0, Date.new(1985, 1, 1)],
  [171774601.6, Date.new(1986, 1, 1)],
  [175210093.6, Date.new(1987, 1, 1)],
  [178714295.5, Date.new(1988, 1, 1)],
  [182288581.4, Date.new(1989, 1, 1)],
  [185934353, Date.new(1990, 1, 1)],
  [189653040.1, Date.new(1991, 1, 1)],
  [193446100.9, Date.new(1992, 1, 1)],
  [197315022.9, Date.new(1993, 1, 1)],
  [201261323.3, Date.new(1994, 1, 1)],
  [205286549.8, Date.new(1995, 1, 1)],
  [209392280.8, Date.new(1996, 1, 1)],
  [213580126.4, Date.new(1997, 1, 1)],
  [217851728.9, Date.new(1998, 1, 1)],
  [222208763.5, Date.new(1999, 1, 1)],
  [70921057.8, Date.new(2000, 1, 1)],
  [72339479, Date.new(2001, 1, 1)],
  [73786268.6, Date.new(2002, 1, 1)],
  [75261993.9, Date.new(2003, 1, 1)],
  [76767233.8, Date.new(2004, 1, 1)],
  [78302578.5, Date.new(2005, 1, 1)],
  [79868630.1, Date.new(2006, 1, 1)],
  [81466002.7, Date.new(2007, 1, 1)],
  [83095322.7, Date.new(2008, 1, 1)],
  [84757229.2, Date.new(2009, 1, 1)],
  [86452373.8, Date.new(2010, 1, 1)],
  [-34820484.1, Date.new(2011, 1, 1)]
]

FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-6)
## Result -> 0.07847697615499946


FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-6, initial_bracket:[-0.90,1])
## Result -> -0.7111928783960864
```




