### PR TITLE
Fix: Handle Zero Cash Flows Correctly in XIRR Calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Fixed: Calculate xirr now returns 0.0 for arrays containing only zero-amount cashflows, instead of returning the initial guess.
+
 ## 1.1.0
 ! IMPORTANT: This version modifies default values. While not introducing breaking changes, it may produce different results compared to the previous version.
 

--- a/fast_xirr.gemspec
+++ b/fast_xirr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "fast_xirr"
-  spec.version       = "1.1.0"
+  spec.version       = "1.1.1"
   spec.authors       = ["Matias Martini"]
   spec.email         = ["martini@fintual.com"]
 

--- a/lib/fast_xirr/version.rb
+++ b/lib/fast_xirr/version.rb
@@ -1,4 +1,4 @@
 module FastXirr
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end
 

--- a/spec/fast_xirr_spec.rb
+++ b/spec/fast_xirr_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe FastXirr do
       expect(result).to be_nan
     end
 
+    it 'calculates xirr with zero-amount cashflows and gets same result as if they were excluded' do
+      cashflows = [
+        [1000, Date.new(1985, 1, 1)],
+        [0, Date.new(1986, 1, 1)],
+        [-600, Date.new(1990, 1, 1)],
+        [0, Date.new(1991, 1, 1)],
+        [-6000, Date.new(1995, 1, 1)],
+        [0, Date.new(1996, 1, 1)]
+      ]
+
+      result = FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-13)
+      expect(result).to be_within(1e-12).of(0.22568333231765117)
+    end
+
     it 'calculates xirr with super low tolerance and a lot of iterations' do
       cashflows = [
         [1000, Date.new(1985, 1, 1)],
@@ -63,6 +77,17 @@ RSpec.describe FastXirr do
       cashflows = []
 
       result = FastXirr.calculate(cashflows: cashflows)
+      expect(result).to be_zero
+    end
+
+    it 'return 0 with array full of cash flows of 0.0 amount' do
+      cashflows = [
+        [0.0, Date.new(1985, 1, 1)],
+        [0.0, Date.new(1990, 1, 1)],
+        [0.0, Date.new(1995, 1, 1)]
+      ]
+
+      result = FastXirr.calculate(cashflows: cashflows, max_iter: 1e10, tol: 1e-13)
       expect(result).to be_zero
     end
   end


### PR DESCRIPTION
## Context

Issue #11 

When calling FastXirr.calculate with transactions containing `0.0`, the function incorrectly returns `10.0` (or any initial guess) instead of `0.0`. This occurs because the Brent method's initial guess (`10.0` or the one passed in the initial bracket argument) satisfies `NPV = 0`, making it appear as a valid solution. However, since zero cash flows have no impact on the calculation, they should be ignored before running the root-finding algorithm.

Currently, the Brent method in `FastXirr` correctly handles cases where no cash flows remain (returning `0.0` as expected). However, the issue arises because zero cash flows are still being included in the computation before reaching the Brent method, leading to incorrect behavior. The fix ensures that zero-value transactions are filtered out earlier in the process.

## Objective 

- Ensure that FastXirr.calculate properly filters out zero cash flows before computation.
- Prevent misleading results by excluding 0.0 and -0.0 values from the XIRR calculation before passing them to the Brent method.

## Changelog

- **Updated**: `calculate_xirr_with_brent` function to process only non-zero cash flows, preventing incorrect root-finding results.
- **Upgrade Version**: New version is `1.1.1` (minor fix). 
- **Updated**: Add changes in changelog.

## QA 

```ruby
fast_trans = [
  [-0.0, Date.new(2025, 1, 1)],
  [0.0, Date.new(2025, 1, 31)]
]

res = FastXirr.calculate(cashflows: fast_trans)
## => 0.0
```
